### PR TITLE
Enable colored help

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use indoc::indoc;
 
 pub fn app() -> App<'static, 'static> {
     let settings = [
+        AppSettings::ColoredHelp,
         AppSettings::InferSubcommands,
         AppSettings::VersionlessSubcommands,
     ];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-use clap;
 use clap::{App, AppSettings, Arg, SubCommand};
 use indoc::indoc;
 


### PR DESCRIPTION
This puts the `colors` default feature from `clap` to use for `--help`.

This also fixes clippy on the `cli` module.